### PR TITLE
Fix UDMA not an integer on windows and add console output when patching UDMA

### DIFF
--- a/tpatch.py
+++ b/tpatch.py
@@ -98,8 +98,8 @@ class TitanPatcher(object):
         #
 
         if self._udma > 2:
-            print(f"[*] - 0x800553FE: Patching UDMA to version {self._udma}")
             patch_address = 0x800553FE
+            print(f"[*] - 0x{patch_address:X}: Patching UDMA to version {self._udma}")
             patch_bytes = self._assemble(f"push 0x{0x40+self._udma:02X}", patch_address)
             self._write_bytes(patch_bytes, patch_address)
 

--- a/tpatch.py
+++ b/tpatch.py
@@ -22,6 +22,12 @@ class TitanPatcher(object):
         self.filepath = filepath
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
+        
+        if udma.isnumeric():
+            #set udma to int type
+            udma = int(udma)
+
+        assert udma.isnumeric(),  f"Invalid UDMA mode ({udma})"
 
         assert 2 <= udma <= 5, f"Invalid UDMA mode ({udma})"
         self._udma = udma
@@ -263,7 +269,7 @@ def main(argc, argv):
     print(f"[*] Patching with Titan v{VERSION} -- by {AUTHOR}")
 
     # attempt to patch the given kernel image
-    patcher = TitanPatcher(udma=int(args.udma))
+    patcher = TitanPatcher(udma=args.udma)
     patcher.patch_kernel(kernel_filepath, args.force)
 
     print("[+] Patching successful!")

--- a/tpatch.py
+++ b/tpatch.py
@@ -23,7 +23,7 @@ class TitanPatcher(object):
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
 
-        assert udma.isnumeric(),  f"Invalid UDMA mode ({udma})"
+        assert udma.isnumeric(), f"Invalid UDMA mode ({udma})"
         
         if udma.isnumeric():
             #set udma to int type

--- a/tpatch.py
+++ b/tpatch.py
@@ -22,12 +22,12 @@ class TitanPatcher(object):
         self.filepath = filepath
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
+
+        assert udma.isnumeric(),  f"Invalid UDMA mode ({udma})"
         
         if udma.isnumeric():
             #set udma to int type
-            udma = int(udma)
-
-        assert udma.isnumeric(),  f"Invalid UDMA mode ({udma})"
+            udma = int(udma)        
 
         assert 2 <= udma <= 5, f"Invalid UDMA mode ({udma})"
         self._udma = udma
@@ -283,4 +283,3 @@ def main(argc, argv):
 if __name__ == '__main__':
     result = main(len(sys.argv), sys.argv)
     sys.exit(result)
-    

--- a/tpatch.py
+++ b/tpatch.py
@@ -23,8 +23,8 @@ class TitanPatcher(object):
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
 
-        assert 2 <= udma <= 5, f"Invalid UDMA mode ({udma})"
-        self._udma = udma
+        assert 2 <= int(udma) <= 5, f"Invalid UDMA mode ({udma})"
+        self._udma = int(udma)
 
         if filepath:
             self.patch_kernel(filepath)
@@ -92,6 +92,7 @@ class TitanPatcher(object):
         #
 
         if self._udma > 2:
+            print(f"[*] - 0x800553FE: Patching UDMA to version {self._udma}")
             patch_address = 0x800553FE
             patch_bytes = self._assemble(f"push 0x{0x40+self._udma:02X}", patch_address)
             self._write_bytes(patch_bytes, patch_address)
@@ -259,7 +260,6 @@ def main(argc, argv):
             shutil.copy(kernel_filepath, kernel_filepath_bak)
     except:
         pass
-
     print(f"[*] Patching with Titan v{VERSION} -- by {AUTHOR}")
 
     # attempt to patch the given kernel image
@@ -276,3 +276,4 @@ def main(argc, argv):
 if __name__ == '__main__':
     result = main(len(sys.argv), sys.argv)
     sys.exit(result)
+    

--- a/tpatch.py
+++ b/tpatch.py
@@ -23,8 +23,8 @@ class TitanPatcher(object):
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
 
-        assert 2 <= int(udma) <= 5, f"Invalid UDMA mode ({udma})"
-        self._udma = int(udma)
+        assert 2 <= udma <= 5, f"Invalid UDMA mode ({udma})"
+        self._udma = udma
 
         if filepath:
             self.patch_kernel(filepath)
@@ -263,7 +263,7 @@ def main(argc, argv):
     print(f"[*] Patching with Titan v{VERSION} -- by {AUTHOR}")
 
     # attempt to patch the given kernel image
-    patcher = TitanPatcher(udma=args.udma)
+    patcher = TitanPatcher(udma=int(args.udma))
     patcher.patch_kernel(kernel_filepath, args.force)
 
     print("[+] Patching successful!")

--- a/tpatch.py
+++ b/tpatch.py
@@ -266,6 +266,7 @@ def main(argc, argv):
             shutil.copy(kernel_filepath, kernel_filepath_bak)
     except:
         pass
+    
     print(f"[*] Patching with Titan v{VERSION} -- by {AUTHOR}")
 
     # attempt to patch the given kernel image

--- a/tpatch.py
+++ b/tpatch.py
@@ -9,7 +9,7 @@ from titan.keystone import keystone
 from titan.patches.m8 import KERNEL_PATCHES
 from titan.patches.common import PatchType
 
-VERSION = '1.0'
+VERSION = '1.0.1'
 AUTHOR  = 'Markus Gaasedelen'
 
 #------------------------------------------------------------------------------
@@ -22,12 +22,6 @@ class TitanPatcher(object):
         self.filepath = filepath
         self._ks = keystone.Ks(keystone.KS_ARCH_X86, keystone.KS_MODE_32)
         self._fd = None
-
-        assert udma.isnumeric(), f"Invalid UDMA mode ({udma})"
-        
-        if udma.isnumeric():
-            #set udma to int type
-            udma = int(udma)        
 
         assert 2 <= udma <= 5, f"Invalid UDMA mode ({udma})"
         self._udma = udma
@@ -99,7 +93,7 @@ class TitanPatcher(object):
 
         if self._udma > 2:
             patch_address = 0x800553FE
-            print(f"[*] - 0x{patch_address:X}: Patching UDMA to version {self._udma}")
+            print(f"[*] - 0x{patch_address:08X}: Patching UDMA to version {self._udma}")
             patch_bytes = self._assemble(f"push 0x{0x40+self._udma:02X}", patch_address)
             self._write_bytes(patch_bytes, patch_address)
 
@@ -235,6 +229,7 @@ def main(argc, argv):
     parser.add_argument(
         '-u',
         '--udma',
+        type=int,
         help='specify a UDMA mode (2 through 5)',
         default=2 # UDMA MODE 2 (retail)
     )
@@ -266,7 +261,7 @@ def main(argc, argv):
             shutil.copy(kernel_filepath, kernel_filepath_bak)
     except:
         pass
-    
+
     print(f"[*] Patching with Titan v{VERSION} -- by {AUTHOR}")
 
     # attempt to patch the given kernel image


### PR DESCRIPTION
added sanity check/validation in TitanPatcher of the UDMA argument that sets the udma value to type int

added console output to the _patch_m8  self._udma