### PR TITLE
Fix address conflict for m8plus when used with kpatch

### DIFF
--- a/titan/patches/m8.py
+++ b/titan/patches/m8.py
@@ -4,6 +4,14 @@ from .common import XboxPatch, PatchType
 # M8+ Patch Definitions
 #-----------------------------------------------------------------------------
 
+class Patch_MicrocodeLoader(XboxPatch):
+    TYPE = PatchType.INLINE
+    HOOK_ADDRESS = 0x80061DFD
+
+    EXPECTED_LENGTH = 14
+    ASSEMBLY = "\n" + \
+        ("NOP\n" * EXPECTED_LENGTH)
+
 class Patch_HddStartVerify(XboxPatch):
     TYPE = PatchType.INLINE
     HOOK_ADDRESS = 0x800243AA
@@ -433,6 +441,9 @@ class Patch_FatxAsyncIo(XboxPatch):
 
 KERNEL_PATCHES = \
 [
+    # Fix up the microcode loader to avoid using our carved out space
+    Patch_MicrocodeLoader,
+
     # TODO: these should probably patched for completeness but appear unused
     Patch_HddStartVerify,
     Patch_HddVerify,

--- a/tpatch.py
+++ b/tpatch.py
@@ -59,7 +59,8 @@ class TitanPatcher(object):
         """
         Patch the M8 kernel with TITAN.
         """
-        self._prep_cave(0x8003026F, 0x800305C8) # s/o to LoveMhz for the tip
+        # Reuse memory space for preproduction(?) CPU microcode
+        self._prep_cave(0x80061E24, 0x80062624)
 
         for patch in KERNEL_PATCHES:
             patch_name = patch.__name__.split('Patch_')[1] + '(...)'


### PR DESCRIPTION
Move carved space to avoid it conflicting with kpatch.

This new carve space is ~2kB by using an unused microcode update and patching the cpuid check for sanity sake (the cpuid check it nop's out hasn't shown up anywhere from my research and is probably a leftover from very early pre-production hw).