### PR TITLE
Improve sectors per cluster check

### DIFF
--- a/titan/patches/m8.py
+++ b/titan/patches/m8.py
@@ -328,27 +328,22 @@ class Patch_HddCreate(XboxPatch):
     mov     dword ptr ds:[0x8003C3B8+4], ecx
     """
 
-class Patch_FatxParseSupeblock(XboxPatch):
+class Patch_FatxProcessBootSector(XboxPatch):
     TYPE = PatchType.JUMP
-    HOOK_ADDRESS = 0x80027143
-    HOOK_RETURN = 0x800271D9
+    HOOK_ADDRESS = 0x80027116
+    HOOK_RETURN = 0x80027149
 
     ASSEMBLY = \
     """
-    ; 128 clusters per sector
-    jz      0x80027149
-
-    ; 256 clusters per sector
-    sub     ecx, 128
-    jz      0x80027149
-
-    ; 512 clusters per sector
-    sub     ecx, 256
-    jz      0x80027149
-
-    ; 1024 clusters per sector
-    sub     ecx, 512
-    jz      0x80027149
+    ; Check if sectors per cluster is 0 and error if so
+    cmp     eax, 0
+    je      0x800271D9
+    ; Check if sectors per cluster is a power of 2, and error if not
+    mov     ecx, eax
+    sub     ecx, 1
+    and     ecx, eax
+    cmp     ecx, 0
+    jne     0x800271D9
     """
 
 class Patch_FatxStartAsyncIo(XboxPatch):
@@ -450,8 +445,8 @@ KERNEL_PATCHES = \
     Patch_HddCreateQuick,
     Patch_HddCreate,
 
-    # allow larger cluster sizes (up to 512kb)
-    Patch_FatxParseSupeblock,
+    # allow larger cluster sizes
+    Patch_FatxProcessBootSector,
 
     # smuggle sector bits for async disk IO
     Patch_FatxStartAsyncIo,


### PR DESCRIPTION
This proposed update to the SPC check does 3 things:
1. Corrects the name of the patch to be the real name of the function: FatxProcessBootSector.
2. Instead of checking the SPC against a bunch of known valid numbers, it is now checked that it is greater than 0 and a power of 2. This supports all retail cluster sizes, and also allows for larger ones. Now larger cluster sizes can be tested without this patch needing to be tweaked.
3. Changes the logic of the patch to make the return path the success path (made it easier).

This patch translates to the following:
`SectorsPerCluster > 0 && ((SectorsPerCluster - 1) & SectorsPerCluster) == 0`

I do not know the true maximum cluster size that can be used before problems occur. I do not recommend cluster sizes that are too large in order to maintain performance with smaller files. However, larger sizes will increase loading/mounting speed.

**Help Needed:** I do not have the means to test this patch update. I recommend testing before merging.